### PR TITLE
Create pkg directoy in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ echo "compile scheduler to wasm"
 cd ruffbox-pattern
 wasm-pack build --target web
 
+mkdir -p ../js/pkg
 cp -r pkg/* ../js/pkg/
 
 echo "finish!"


### PR DESCRIPTION
On my first build, the `cp` command in the script failed, as the directory didn't exist.